### PR TITLE
SERVER ERROR 505 when uploading.

### DIFF
--- a/app/Http/Livewire/Project/Create.php
+++ b/app/Http/Livewire/Project/Create.php
@@ -64,7 +64,7 @@ class Create extends Component
             'city' => 'required',
             'zip' => 'required',
             'description' => 'required',
-            'attachments.*' => 'max:102400 ', // Requiired validation for attachments
+            'attachments.*' => 'required|file|mimes:jpeg,png,jpg,pdf,doc,docx|max:2048', // Requiired validation for attachments
         ]);
 
         
@@ -99,9 +99,9 @@ class Create extends Component
             
             $fileName = date("Ymd-hi").'-'.$attachment->getClientOriginalName(); // Save the original name of the file along with a time stamp in a variable called fileName
             
-            $path = $attachment->storeAs('attachments', strval($fileName), 's3-public'); // Save attachment on Amazon S3// Store in the "attachment" directory of the local-themischimney.com bucket with original file name.  The file name must be a string so I obtain the string value from the variable.
+            $path = $attachment->storeAs('attachments', strval($fileName), 's3'); // Save attachment on Amazon S3// Store in the "attachment" directory of the local-themischimney.com bucket with original file name.  The file name must be a string so I obtain the string value from the variable.
             
-            $url = 'https://'.env('AWS_BUCKET_PUBLIC').'.s3.amazonaws.com/'.$path; // Put the URL together for the file just uploaded.
+            $url = 'https://'.env('AWS_BUCKET').'.s3.amazonaws.com/'.$path; // Put the URL together for the file just uploaded.
 
             // Create an objec that will include the current parent component object and along with the fileName and $url
             $fileRecord = new Attachment(); // Create a new Attachment object that will store info for the attachment table in MySQL.

--- a/app/Http/Livewire/UploadFiles.php
+++ b/app/Http/Livewire/UploadFiles.php
@@ -58,9 +58,9 @@ class UploadFiles extends Component
 
             $fileName = date("Ymd-hi").'-'.$file->getClientOriginalName(); // Save the original name of the file along with a time stamp in a variable called fileName
 
-            $path = $file->storeAs('attachments', strval($fileName), 's3-public'); // Save attachment on Amazon S3// Store in the "attachment" directory of the local-themischimney.com bucket with original file name.  The file name must be a string so I obtain the string value from the variable.
+            $path = $file->storeAs('attachments', strval($fileName), 's3'); // Save attachment on Amazon S3// Store in the "attachment" directory of the local-themischimney.com bucket with original file name.  The file name must be a string so I obtain the string value from the variable.
 
-            $url = 'https://'.env('AWS_BUCKET_PUBLIC').'.s3.amazonaws.com/'.$path; // Put the URL together for the file just uploaded.
+            $url = 'https://'.env('AWS_BUCKET').'.s3.amazonaws.com/'.$path; // Put the URL together for the file just uploaded.
             
             // Create an objec that will include the current parent component object and along with the fileName and $url
             $fileRecord = new Attachment(); // Create a new Attachment object that will store info for the attachment table in MySQL.


### PR DESCRIPTION
I revised the validation for attachments on the create controller so they match the same validation on the uploadFiles controller.

In the storeAs() method on both the create and upload files controller, I changed the last parameter, which indicates the driver to use, from S3-public to S3.

For the URL variable on both the create and upload files controller,, I change the environment variable to point to AWS_BUCKET rather than AWS_BUCKET_PUBLIC since we are not using the public driver.

I created a folder called 'attachments' within the AWS Bucket online.

I confirmed that the attachment is uploading to the AWS bucket to both the Livewire-temp folder and the attachments folder.  I also confirmed that the path file is saving correctly on the database table for attachments.

I cannot view the attachment because I don't have the correct permissions assisned on the bucket.  I opened up another issue for that.